### PR TITLE
Entry resource

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pep8==1.7.0
 py==1.4.31
 pytest==2.9.0
 requests==2.9.1
+jsonschema==2.5.1

--- a/tests/test_entries_resource.py
+++ b/tests/test_entries_resource.py
@@ -1,0 +1,42 @@
+import pytest
+import requests
+
+from urllib.parse import urljoin
+
+from jsonschema import validate
+
+
+class TestEntriesResourceJson(object):
+    @pytest.fixture
+    def response(self, endpoint):
+        return requests.get(urljoin(endpoint, 'entries.json'))
+
+    def test_content_type(self, response):
+        assert response.headers['content-type'] == 'application/json'
+
+    @pytest.mark.xfail
+    def test_response_contents(self, response):
+        #This schema should always represent the response json specified at <http://openregister.github.io/specification/#entries-resource>
+        entries_schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "entry-number": {
+                        "type": "string",
+                        "pattern": "^\d+$"
+                    },
+                    "item-hash": {
+                        "type": "string",
+                        "pattern": "^sha-256:[a-z\d]+$"
+                    },
+                    "entry-timestamp": {
+                        "type": "string",
+                        "pattern": "^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
+                    }
+                },
+                "required": ["entry-number", "item-hash", "entry-timestamp"],
+                "additionalProperties": False
+            }
+        }
+        validate(response.json(), entries_schema)

--- a/tests/test_entries_resource.py
+++ b/tests/test_entries_resource.py
@@ -28,7 +28,7 @@ class TestEntriesResourceJson(object):
                     },
                     "item-hash": {
                         "type": "string",
-                        "pattern": "^sha-256:[a-z\d]+$"
+                        "pattern": "^sha-256:[a-f\d]{64}$"
                     },
                     "entry-timestamp": {
                         "type": "string",

--- a/tests/test_entry_resource.py
+++ b/tests/test_entry_resource.py
@@ -1,6 +1,8 @@
 import pytest
 import requests
+
 from urllib.parse import urljoin
+from jsonschema import validate
 
 
 class TestEntryResourceJson(object):
@@ -12,7 +14,26 @@ class TestEntryResourceJson(object):
         assert response.headers['content-type'] == 'application/json'
 
     @pytest.mark.xfail
-    def test_content_fieldnames(self, response):
-        assert 'entry-number' in response.json(), \
-            '''Missing required field `entry-number`
-            Ref: http://openregister.github.io/specification/#assert-df4a8358'''
+    def test_response_contents(self, response):
+        #This schema should always represent the response json specified at <http://openregister.github.io/specification/#entry-resource>
+        entry_schema = {
+            "type": "object",
+            "properties": {
+                "entry-number": {
+                    "type": "string",
+                    "pattern": "^\d+$"
+                },
+                "item-hash": {
+                    "type": "string",
+                    "pattern": "^sha-256:[a-z\d]+$"
+                },
+                "entry-timestamp": {
+                    "type": "string",
+                    "pattern": "^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
+                }
+            },
+            "required": ["entry-number", "item-hash", "entry-timestamp"],
+            "additionalProperties": False
+        }
+
+        validate(response.json(), entry_schema)

--- a/tests/test_entry_resource.py
+++ b/tests/test_entry_resource.py
@@ -13,7 +13,6 @@ class TestEntryResourceJson(object):
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'application/json'
 
-    @pytest.mark.xfail
     def test_response_contents(self, response):
         #This schema should always represent the response json specified at <http://openregister.github.io/specification/#entry-resource>
         entry_schema = {
@@ -25,7 +24,7 @@ class TestEntryResourceJson(object):
                 },
                 "item-hash": {
                     "type": "string",
-                    "pattern": "^sha-256:[a-z\d]+$"
+                    "pattern": "^sha-256:[a-f\d]{64}$"
                 },
                 "entry-timestamp": {
                     "type": "string",


### PR DESCRIPTION
Added conformance test for new `\entry` and `\entries` resources. 
These are still marked xfail at the moment because the work on these resources are still under development. 
