### PR TITLE
fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pep8==1.7.0
 py==1.4.31
 pytest==2.9.0
+PyYAML==3.11
 requests==2.9.1
 jsonschema==2.5.1
 Werkzeug==0.11.5

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(name='openregister-conformance',
       tests_require=['pytest>=2.9.0'],
       install_requires=[
         'pytest>=2.9.0',
-        'requests>=2.9.1'
+        'PyYAML>=3.11',
+        'requests>=2.9.1',
+        'Werkzeug>=0.11.5'
       ]
 )


### PR DESCRIPTION
When installing from elsewhere, we need to specify dependencies in the
setup.py.  Added pyyaml and werkzeug here.

We were also missing pyyaml from the requirements.txt.
