### PR TITLE
Add test for `/record/<key>/entries` resource

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,13 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption("--endpoint", action="append",
-        help="register endpoints to test")
+                     help="register endpoints to test")
 
 
 def pytest_generate_tests(metafunc):
     if 'endpoint' in metafunc.fixturenames:
         metafunc.parametrize("endpoint",
-            metafunc.config.option.endpoint)
+                             metafunc.config.option.endpoint)
 
 
 @pytest.fixture(scope="session")
@@ -35,3 +35,28 @@ def entry_schema():
         "additionalProperties": False
     }
 
+@pytest.fixture(scope="session")
+def entries_schema():
+    # This schema should always represent the response json specified at <http://openregister.github.io/specification/#entries-resource>
+    return {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "entry-number": {
+                    "type": "string",
+                    "pattern": "^\d+$"
+                },
+                "item-hash": {
+                    "type": "string",
+                    "pattern": "^sha-256:[a-f\d]{64}$"
+                },
+                "entry-timestamp": {
+                    "type": "string",
+                    "pattern": "^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
+                }
+            },
+            "required": ["entry-number", "item-hash", "entry-timestamp"],
+            "additionalProperties": False
+        }
+    }

--- a/tests/test_entries_resource.py
+++ b/tests/test_entries_resource.py
@@ -7,28 +7,6 @@ from jsonschema import validate
 from werkzeug.http import parse_options_header
 
 #This schema should always represent the response json specified at <http://openregister.github.io/specification/#entries-resource>
-ENTRIES_SCHEMA = {
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "entry-number": {
-                "type": "string",
-                "pattern": "^\d+$"
-            },
-            "item-hash": {
-                "type": "string",
-                "pattern": "^sha-256:[a-f\d]{64}$"
-            },
-            "entry-timestamp": {
-                "type": "string",
-                "pattern": "^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
-            }
-        },
-        "required": ["entry-number", "item-hash", "entry-timestamp"],
-        "additionalProperties": False
-    }
-}
 
 class TestEntriesResourceJson(object):
     @pytest.fixture
@@ -38,9 +16,8 @@ class TestEntriesResourceJson(object):
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'application/json'
 
-    def test_response_contents(self, response):
-        
-        validate(response.json(), ENTRIES_SCHEMA)
+    def test_response_contents(self, response, entries_schema):
+        validate(response.json(), entries_schema)
 
 class TestEntriesResourceYaml(object):
     @pytest.fixture
@@ -51,5 +28,5 @@ class TestEntriesResourceYaml(object):
         assert parse_options_header(response.headers['content-type']) \
             == ('text/yaml', {'charset':'UTF-8'})
 
-    def test_response_contents(self, response):
-        validate(yaml.load(response.text), ENTRIES_SCHEMA)
+    def test_response_contents(self, response, entries_schema):
+        validate(yaml.load(response.text), entries_schema)

--- a/tests/test_record_entries_resource.py
+++ b/tests/test_record_entries_resource.py
@@ -1,0 +1,25 @@
+import pytest
+import requests
+import re
+
+from urllib.parse import urljoin
+from jsonschema import validate
+
+class TestRecordEntriesResourceJson(object):
+    @pytest.fixture
+    def response(self, endpoint):
+        register_name = re.sub(r'http[s]?://([^\.]+)(.*)', r'\1', endpoint)
+
+        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()
+
+        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'])).json()
+
+        return requests.get(urljoin(endpoint, '/record/%s' % item_json[register_name]))
+
+    @pytest.mark.xfail
+    def test_content_type(self, response):
+        assert response.headers['content-type'] == 'application/json'
+
+    @pytest.mark.xfail
+    def test_response_contents(self, response, entries_schema):
+        validate(response.json(), entries_schema)


### PR DESCRIPTION
Currently marked xfail as the code is not yet deployed in beta environment.
