### PR TITLE
Add conformance tests for yaml and csv for new resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+csvvalidator==1.2
 pep8==1.7.0
 py==1.4.31
 pytest==2.9.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from csvvalidator import *
+
 
 def pytest_addoption(parser):
     parser.addoption("--endpoint", action="append",
@@ -60,3 +62,12 @@ def entries_schema():
             "additionalProperties": False
         }
     }
+    
+@pytest.fixture(scope="session")
+def entry_csv_schema():
+    validator = CSVValidator(('entry-number', 'item-hash', 'entry-timestamp'))
+    validator.add_header_check()
+    validator.add_value_check('entry-number', str, match_pattern('^\d+$'))
+    validator.add_value_check('item-hash', str, match_pattern('^sha-256:[a-f\d]{64}$'))
+    validator.add_value_check('entry-timestamp', str, match_pattern('^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$'))
+    return validator

--- a/tests/test_entry_resource.py
+++ b/tests/test_entry_resource.py
@@ -1,3 +1,4 @@
+import csv
 import pytest
 import requests
 import yaml
@@ -17,7 +18,6 @@ class TestEntryResourceJson(object):
     def test_response_contents(self, response, entry_schema):
         validate(response.json(), entry_schema)
 
-
 class TestEntryResourceYaml(object):
     @pytest.fixture
     def response(self, endpoint):
@@ -29,3 +29,19 @@ class TestEntryResourceYaml(object):
 
     def test_response_contents(self, response, entry_schema):
         validate(yaml.load(response.text), entry_schema)
+
+class TestEntryResourceCsv(object):
+    @pytest.fixture
+    def response(self, endpoint):
+        return requests.get(urljoin(endpoint, 'entry/1.csv'))
+
+    def test_content_type(self, response):
+        assert parse_options_header(response.headers['content-type']) \
+            == ('text/csv', {'charset':'UTF-8'})
+
+    def test_response_contents(self, response, entry_csv_schema):
+        problems = entry_csv_schema.validate(csv.reader(response.text.split('\r\n')))
+        assert problems == [], \
+            'There is a problem with Entry resource csv'
+
+

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -1,9 +1,12 @@
+import csv
 import pytest
 import requests
 import re
+import yaml
 
+from csvvalidator import *
 from urllib.parse import urljoin
-
+from werkzeug.http import parse_options_header
 
 class TestItemResourceJson(object):
     @pytest.fixture
@@ -23,3 +26,47 @@ class TestItemResourceJson(object):
 
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'application/json'
+
+class TestItemResourceYaml(object):
+    @pytest.fixture
+    def response(self, endpoint):
+        entry = requests.get(urljoin(endpoint, 'entry/1.json'))
+
+        item_hash = entry.json()['item-hash']
+
+        return requests.get(urljoin(endpoint, 'item/' + item_hash + '.yaml'))
+
+    def test_response_contents(self, response, endpoint):
+        register_data = requests.get(urljoin(endpoint, '/register.json'))
+        register_fields = register_data.json()['record']['entry']['fields']
+
+        assert set(yaml.load(response.text).keys()).issubset(register_fields), \
+            'Item json does not match fields specified in regsiter register'
+
+    def test_content_type(self, response):
+        assert parse_options_header(response.headers['content-type']) \
+            == ('text/yaml', {'charset':'UTF-8'})
+
+class TestItemResourceCsv(object):
+    @pytest.fixture
+    def response(self, endpoint):
+        entry = requests.get(urljoin(endpoint, 'entry/1.json'))
+
+        item_hash = entry.json()['item-hash']
+
+        return requests.get(urljoin(endpoint, 'item/' + item_hash + '.csv'))
+
+    def test_response_contents(self, response, endpoint):
+        register_data = requests.get(urljoin(endpoint, '/register.json'))
+        register_fields = register_data.json()['record']['entry']['fields']
+
+        validator = CSVValidator(register_fields)
+        validator.add_header_check()
+        problems = validator.validate(csv.reader(response.text.split('\r\n')))
+
+        assert problems == [], \
+            'There is a problem with Item resource csv'
+
+    def test_content_type(self, response):
+        assert parse_options_header(response.headers['content-type']) \
+            == ('text/csv', {'charset':'UTF-8'})

--- a/tests/test_record_entries_resource.py
+++ b/tests/test_record_entries_resource.py
@@ -1,9 +1,12 @@
+import csv
 import pytest
 import requests
 import re
+import yaml
 
 from urllib.parse import urljoin
 from jsonschema import validate
+from werkzeug.http import parse_options_header
 
 class TestRecordEntriesResourceJson(object):
     @pytest.fixture
@@ -14,12 +17,48 @@ class TestRecordEntriesResourceJson(object):
 
         item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'])).json()
 
-        return requests.get(urljoin(endpoint, '/record/%s/entries' % item_json[register_name]))
+        return requests.get(urljoin(endpoint, '/record/%s/entries.json' % item_json[register_name]))
 
-    @pytest.mark.xfail
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'application/json'
 
-    @pytest.mark.xfail
     def test_response_contents(self, response, entries_schema):
         validate(response.json(), entries_schema)
+
+class TestRecordEntriesResourceYaml(object):
+    @pytest.fixture
+    def response(self, endpoint):
+        register_name = re.sub(r'http[s]?://([^\.]+)(.*)', r'\1', endpoint)
+
+        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()
+
+        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'])).json()
+
+        return requests.get(urljoin(endpoint, '/record/%s/entries.yaml' % item_json[register_name]))
+
+    def test_content_type(self, response):
+        assert parse_options_header(response.headers['content-type']) \
+            == ('text/yaml', {'charset':'UTF-8'})
+
+    def test_response_contents(self, response, entries_schema):
+        validate(yaml.load(response.text), entries_schema)
+
+class TestRecordEntriesResourceCsv(object):
+    @pytest.fixture
+    def response(self, endpoint):
+        register_name = re.sub(r'http[s]?://([^\.]+)(.*)', r'\1', endpoint)
+
+        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()
+
+        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'])).json()
+
+        return requests.get(urljoin(endpoint, '/record/%s/entries.csv' % item_json[register_name]))
+
+    def test_content_type(self, response):
+        assert parse_options_header(response.headers['content-type']) \
+            == ('text/csv', {'charset':'UTF-8'})
+
+    def test_response_contents(self, response, entry_csv_schema):
+        problems = entry_csv_schema.validate(csv.reader(response.text.split('\r\n')))
+        assert problems == [], \
+            'There is a problem with Record Entries resource csv'

--- a/tests/test_record_resource.py
+++ b/tests/test_record_resource.py
@@ -1,10 +1,13 @@
+import csv
 import pytest
 import requests
 import re
+import yaml
 
-from urllib.parse import urljoin
+from csvvalidator import *
 from jsonschema import validate
-
+from urllib.parse import urljoin
+from werkzeug.http import parse_options_header
 
 class TestRecordResourceJson(object):
     @pytest.fixture
@@ -37,3 +40,67 @@ class TestRecordResourceJson(object):
 
         assert set(record_json.keys()).issubset(register_fields), \
             'Record contains unrecognized keys'
+
+class TestRecordResourceYaml(object):
+    @pytest.fixture
+    def response(self, endpoint):
+        register_name = re.sub(r'http[s]?://([^\.]+)(.*)', r'\1', endpoint)
+
+        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()
+
+        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'])).json()
+
+        return requests.get(urljoin(endpoint, '/record/%s.yaml' % item_json[register_name]))
+
+    def test_content_type(self, response):
+        assert parse_options_header(response.headers['content-type']) \
+            == ('text/yaml', {'charset':'UTF-8'})
+
+    def test_response_contents(self, response, endpoint, entry_schema):
+        record_yaml = yaml.load(response.text)
+
+        entry_part = {
+            'entry-number': record_yaml.pop('entry-number'),
+            'item-hash': record_yaml.pop('item-hash'),
+            'entry-timestamp': record_yaml.pop('entry-timestamp')
+        }
+
+        validate(entry_part, entry_schema)
+
+        register_data = requests.get(urljoin(endpoint, '/register.json'))
+
+        register_fields = register_data.json()['record']['entry']['fields']
+
+        assert set(record_yaml.keys()).issubset(register_fields), \
+            'Record contains unrecognized keys'
+
+class TestRecordResourceCsv(object):
+    @pytest.fixture
+    def response(self, endpoint):
+        register_name = re.sub(r'http[s]?://([^\.]+)(.*)', r'\1', endpoint)
+
+        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()
+
+        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'])).json()
+
+        return requests.get(urljoin(endpoint, '/record/%s.csv' % item_json[register_name]))
+
+    def test_content_type(self, response):
+        assert parse_options_header(response.headers['content-type']) \
+            == ('text/csv', {'charset':'UTF-8'})
+
+    def test_response_contents(self, response, endpoint, entry_schema):
+        field_names = ['entry-number', 'item-hash', 'entry-timestamp']
+        register_data = requests.get(urljoin(endpoint, '/register.json'))
+        register_fields = register_data.json()['record']['entry']['fields']
+        field_names += register_fields
+
+        validator = CSVValidator(field_names)
+        validator.add_header_check()
+        validator.add_value_check('entry-number', str, match_pattern('^\d+$'))
+        validator.add_value_check('item-hash', str, match_pattern('^sha-256:[a-f\d]{64}$'))
+        validator.add_value_check('entry-timestamp', str, match_pattern('^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$'))
+        problems = validator.validate(csv.reader(response.text.split('\r\n')))
+
+        assert problems == [], \
+            'There is a problem with Record resource csv'


### PR DESCRIPTION
New tests for yaml for Item, Record and Record Entries resources.
New tests for csv for Entry, Entries, Item, Record and Record Entries resources.

Removed xfail from Record Entries resource tests as this resource has now been deployed to all environments.
