### PR TITLE
Makes better use of json-schema to test the changes to record resource

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,13 +70,19 @@ def entries_schema():
 def record_schema():
     return {
         'type': 'object',
-        'properties': {
-            **types.INDEX_ENTRY_NUMBER,
-            **types.ENTRY_NUMBER,
-            **types.ENTRY_KEY,
-            **types.ENTRY_TIMESTAMP,
+        'patternProperties': {
+            ".*": {
+                'properties': {
+                    **types.INDEX_ENTRY_NUMBER,
+                    **types.ENTRY_NUMBER,
+                    **types.ENTRY_KEY,
+                    **types.ENTRY_TIMESTAMP,
+                    **types.ITEM
+                },
+                'required': ['index-entry-number', 'entry-number', 'key', 'entry-timestamp'],
+                'additionalProperties': False
+            }
         },
-        'required': ['index-entry-number', 'entry-number', 'key', 'entry-timestamp'],
         'additionalProperties': False
     }
 

--- a/tests/data_types.py
+++ b/tests/data_types.py
@@ -35,6 +35,15 @@ ITEM_HASH_ARRAY = {
     }
 }
 
+ITEM = {
+    'item': {
+        'type': 'array',
+        'items': {
+            'type': 'object'
+        }
+    }
+}
+
 ENTRY_TIMESTAMP = {
     'entry-timestamp': {
         'type': 'string',


### PR DESCRIPTION
Also mark the YAML test for the record resource as xfail for now. This is
because this test currently fails for registers that use "integers" for keys.
This happens because we do not surround our keys with quotes in our API and the python yaml
library attempts to convert this into various datatypes. We then get a string comparison failure.
We need to work out if this is a problem with our API or the YAML library before removing the xfail.