### PR TITLE
Update conformance tests to test against multiple versions of the specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 *.egg-info
 .idea
 *.egg
+conform/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Example of running tests against `localhost`:
 openregister-conformance --no-https --register school --register-domain openregister.local:8080  --api-version 1 http://localhost:8080/v1/
 ```
 
-The `api-version` option should be set to the version of the [specification][] you want to test against. Currently only one version is available, but we are working on a new version, which will include any backwards-incompatable API changes from [accepted RFCs](https://github.com/openregister/registers-rfcs). To test against this version, run:
+The `api-version` option should be set to the version of the [specification][] you want to test against. For example, to test against version 2, run:
 
 ```
 openregister-conformance --no-https --register school --register-domain openregister.org:8080  --api-version 2 http://localhost:8080/next/
@@ -37,5 +37,5 @@ Unless stated otherwise, this codebase is released under [the MIT
 license](./LICENSE).
 
 
-[specification]: https://openregister.github.io/specification/
+[specification]: https://spec.openregister.org
 [xfail]: https://pytest.org/latest/skipping.html

--- a/README.md
+++ b/README.md
@@ -7,11 +7,17 @@ Usage:
     $ python3 -m venv conform
     $ source conform/bin/activate
     (conform) $ pip install -e . -r requirements.txt
-    (conform) $ openregister-conformance https://url-of-register [https://another-register ...]
+    (conform) $ openregister-conformance --api-version version-number https://url-of-register [https://another-register ...]
 
 Example of running tests against `localhost`:
 ```
-openregister-conformance --no-https --register school --register-domain openregister.local:8080 http://localhost:8080
+openregister-conformance --no-https --register school --register-domain openregister.local:8080  --api-version 1 http://localhost:8080
+```
+
+The `api-version` option should be set to the version of the [specification][] you want to test against. Currently only one version is available, but we are working on a new version, which will include any backwards-incompatable API changes from [accepted RFCs](https://github.com/openregister/registers-rfcs). To test against this version, run:
+
+```
+openregister-conformance --no-https --register school --register-domain openregister.org:8080  --api-version 2 http://localhost:8080
 ```
 
 There may be tests for future work that has not been implemented yet.
@@ -20,7 +26,7 @@ These are marked with [`xfail`][xfail] annotations.  The
 not worry if they fail.  To force these tests to run, run them with
 `py.test` using the `--runxfail` parameter:
 
-    py.test --runxfail --endpoint https://url-of-register [--endpoint https://another-register ...]
+    py.test --runxfail --endpoint 'http://localhost:8080' --api-version 1 --register school --register-domain 'openregister.org:8080' -m 'not https'
 
 Note that passing all of the tests does not guarantee that you have a
 fully-conformant implementation.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Usage:
     $ python3 -m venv conform
     $ source conform/bin/activate
     (conform) $ pip install -e . -r requirements.txt
-    (conform) $ openregister-conformance --api-version version-number https://url-of-register [https://another-register ...]
+    (conform) $ openregister-conformance --api-version version-number --register register-name https://{register-name}.register.gov.uk
 
 Example of running tests against `localhost`:
 ```

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Usage:
 
 Example of running tests against `localhost`:
 ```
-openregister-conformance --no-https --register school --register-domain openregister.local:8080  --api-version 1 http://localhost:8080
+openregister-conformance --no-https --register school --register-domain openregister.local:8080  --api-version 1 http://localhost:8080/v1/
 ```
 
 The `api-version` option should be set to the version of the [specification][] you want to test against. Currently only one version is available, but we are working on a new version, which will include any backwards-incompatable API changes from [accepted RFCs](https://github.com/openregister/registers-rfcs). To test against this version, run:
 
 ```
-openregister-conformance --no-https --register school --register-domain openregister.org:8080  --api-version 2 http://localhost:8080
+openregister-conformance --no-https --register school --register-domain openregister.org:8080  --api-version 2 http://localhost:8080/next/
 ```
 
 There may be tests for future work that has not been implemented yet.

--- a/openregister-conformance
+++ b/openregister-conformance
@@ -10,6 +10,7 @@ parser.add_argument("endpoint", help="URL of register to test")
 parser.add_argument("--register", help="name of the register to run conformance tests for")
 parser.add_argument("--no-https", help="suppress tests for HTTPS functionality", action="store_true")
 parser.add_argument("--register-domain", help="domain of the register")
+parser.add_argument("--api-version", help="API version to test against", required=True)
 
 args = parser.parse_args()
 
@@ -20,8 +21,14 @@ pytest_args = [base_dir, '-q', '-s']
 if args.no_https:
     pytest_args += ['-m', 'not https']
 
+endpoint = args.endpoint
+
+if args.api_version and args.api_version not in ('1', '2'):
+        raise ValueError('Supported API versions are "1" and "2"')
+
 print(args.endpoint)
 pytest_args += ['--endpoint', args.endpoint]
+pytest_args += ['--api-version', args.api_version]
 pytest_args += ['--register', args.register]
 pytest_args += ['--register-domain', args.register_domain]
 

--- a/openregister-conformance
+++ b/openregister-conformance
@@ -32,4 +32,6 @@ pytest_args += ['--api-version', args.api_version]
 pytest_args += ['--register', args.register]
 pytest_args += ['--register-domain', args.register_domain]
 
+pytest_args += ['-W', 'ignore::DeprecationWarning:jsonschema.compat', '-W', 'ignore::DeprecationWarning:yaml.constructor']
+
 raise SystemExit(pytest.main(pytest_args))

--- a/openregister-conformance
+++ b/openregister-conformance
@@ -21,12 +21,9 @@ pytest_args = [base_dir, '-q', '-s']
 if args.no_https:
     pytest_args += ['-m', 'not https']
 
-endpoint = args.endpoint
-
 if args.api_version and args.api_version not in ('1', '2'):
         raise ValueError('Supported API versions are "1" and "2"')
 
-print(args.endpoint)
 pytest_args += ['--endpoint', args.endpoint]
 pytest_args += ['--api-version', args.api_version]
 pytest_args += ['--register', args.register]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,13 +26,7 @@ def pytest_runtest_setup(item):
 def pytest_generate_tests(metafunc):
     if 'endpoint' in metafunc.fixturenames:
         endpoints = metafunc.config.option.endpoint
-        version = metafunc.config.option.api_version
-        if version == 2:
-            endpoint = endpoints[0] + '/next/'
-        else:
-            endpoint = endpoints[0]
-
-        metafunc.parametrize('endpoint', [endpoint])
+        metafunc.parametrize('endpoint', endpoints)
 
     if 'register' in metafunc.fixturenames:
         metafunc.parametrize('register', metafunc.config.option.register)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture(scope='session')
-def entry_schema():
-    # This schema should always represent the response json specified at
-    # <http://openregister.github.io/specification/#entry-resource>
+def entry_schema_v1():
     return {
             'type': 'array',
             'minItems': 1,
@@ -63,11 +61,29 @@ def entry_schema():
             }
         }
 
+@pytest.fixture(scope='session')
+def entry_schema_v2():
+    return {
+            'type': 'array',
+            'minItems': 1,
+            'maxItems': 1,
+            'items': {
+                'type': 'object',
+                'properties': {
+                    **types.INDEX_ENTRY_NUMBER,
+                    **types.ENTRY_NUMBER,
+                    **types.BLOB_HASH_ARRAY,
+                    **types.ENTRY_TIMESTAMP,
+                    **types.ENTRY_KEY
+                },
+                'required': ['index-entry-number','entry-number', 'blob-hash', 'entry-timestamp', 'key'],
+                'additionalProperties': False
+            }
+        }
+
 
 @pytest.fixture(scope='session')
-def entries_schema():
-    # This schema should always represent the response json specified at
-    # <http://openregister.github.io/specification/#entries-resource>
+def entries_schema_v1():
     return {
         'type': 'array',
         'items': {
@@ -80,6 +96,25 @@ def entries_schema():
                 **types.ENTRY_KEY
             },
             'required': ['index-entry-number','entry-number', 'item-hash', 'entry-timestamp', 'key'],
+            'additionalProperties': False
+        }
+    }
+
+
+@pytest.fixture(scope='session')
+def entries_schema_v2():
+    return {
+        'type': 'array',
+        'items': {
+            'type': 'object',
+            'properties': {
+                **types.INDEX_ENTRY_NUMBER,
+                **types.ENTRY_NUMBER,
+                **types.BLOB_HASH_ARRAY,
+                **types.ENTRY_TIMESTAMP,
+                **types.ENTRY_KEY
+            },
+            'required': ['index-entry-number','entry-number', 'blob-hash', 'entry-timestamp', 'key'],
             'additionalProperties': False
         }
     }
@@ -107,12 +142,24 @@ def record_schema():
 
 
 @pytest.fixture(scope='session')
-def entry_csv_schema():
+def entry_csv_schema_v1():
     validator = CSVValidator(('index-entry-number', 'entry-number', 'entry-timestamp', 'key', 'item-hash'))
     validator.add_header_check()
     validator.add_value_check('index-entry-number', str, match_pattern(types.ENTRY_NUMBER_PATTERN))
     validator.add_value_check('entry-number', str, match_pattern(types.ENTRY_NUMBER_PATTERN))
     validator.add_value_check('item-hash', str, match_pattern(types.HASH_PATTERN))
+    validator.add_value_check('entry-timestamp', str, match_pattern(types.TIMESTAMP_PATTERN))
+    validator.add_value_check('key', str, match_pattern(types.KEY_PATTERN))
+    return validator
+
+
+@pytest.fixture(scope='session')
+def entry_csv_schema_v2():
+    validator = CSVValidator(('index-entry-number', 'entry-number', 'entry-timestamp', 'key', 'blob-hash'))
+    validator.add_header_check()
+    validator.add_value_check('index-entry-number', str, match_pattern(types.ENTRY_NUMBER_PATTERN))
+    validator.add_value_check('entry-number', str, match_pattern(types.ENTRY_NUMBER_PATTERN))
+    validator.add_value_check('blob-hash', str, match_pattern(types.HASH_PATTERN))
     validator.add_value_check('entry-timestamp', str, match_pattern(types.TIMESTAMP_PATTERN))
     validator.add_value_check('key', str, match_pattern(types.KEY_PATTERN))
     return validator

--- a/tests/data_types.py
+++ b/tests/data_types.py
@@ -35,6 +35,16 @@ ITEM_HASH_ARRAY = {
     }
 }
 
+BLOB_HASH_ARRAY = {
+    'blob-hash': {
+        'type': 'array',
+        'items': {
+            'type': 'string',
+            'pattern': HASH_PATTERN
+        }
+    }
+}
+
 ITEM = {
     'item': {
         'type': 'array',

--- a/tests/test_entries_resource.py
+++ b/tests/test_entries_resource.py
@@ -19,24 +19,26 @@ class TestEntriesResourceJson(object):
         assert response.headers['content-type'] == 'application/json'
 
     @pytest.mark.version(1)
+    def test_response_contents(self, response, entries_schema_v1):
+        validate(response.json(), entries_schema_v1)
+
     @pytest.mark.version(2)
-    def test_response_contents(self, response, entries_schema):
-        validate(response.json(), entries_schema)
+    def test_response_contents(self, response, entries_schema_v2):
+        validate(response.json(), entries_schema_v2)
 
 
+@pytest.mark.version(1)
 class TestEntriesResourceYaml(object):
     @pytest.fixture
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries.yaml'))
 
-    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/yaml', {'charset': 'UTF-8'})
 
-    @pytest.mark.version(1)
-    def test_response_contents(self, response, entries_schema):
-        validate(yaml.load(response.text), entries_schema)
+    def test_response_contents(self, response, entries_schema_v1):
+        validate(yaml.load(response.text), entries_schema_v1)
 
 
 class TestEntriesResourceCsv(object):
@@ -51,41 +53,44 @@ class TestEntriesResourceCsv(object):
                == ('text/csv', {'charset': 'UTF-8'})
 
     @pytest.mark.version(1)
+    def test_response_contents(self, response, entry_csv_schema_v1):
+        problems = entry_csv_schema_v1.validate(csv.reader(response.text.split('\r\n')))
+        assert problems == [], \
+            'There is a problem with Entries resource csv'
+
     @pytest.mark.version(2)
-    def test_response_contents(self, response, entry_csv_schema):
-        problems = entry_csv_schema.validate(csv.reader(response.text.split('\r\n')))
+    def test_response_contents(self, response, entry_csv_schema_v2):
+        problems = entry_csv_schema_v2.validate(csv.reader(response.text.split('\r\n')))
         assert problems == [], \
             'There is a problem with Entries resource csv'
 
 
+@pytest.mark.version(1)
 class TestEntriesResourceTsv(object):
     @pytest.fixture
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries.tsv'))
 
-    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/tab-separated-values', {'charset': 'UTF-8'})
 
-    @pytest.mark.version(1)
-    def test_response_contents(self, response, entry_csv_schema):
-        problems = entry_csv_schema.validate(csv.reader(response.text.split('\n'), delimiter='\t'))
+    def test_response_contents(self, response, entry_csv_schema_v1):
+        problems = entry_csv_schema_v1.validate(csv.reader(response.text.split('\n'), delimiter='\t'))
         assert problems == [], \
             'There is a problem with Entries resource tsv'
 
 
+@pytest.mark.version(1)
 class TestEntriesResourceTtl(object):
     @pytest.fixture
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries.ttl'))
 
-    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/turtle', {'charset': 'UTF-8'})
 
-    @pytest.mark.version(1)
     def test_response_contents(self, response, entry_ttl_schema):
         entry_ttl_schema.add_data(response.text)
         problems = entry_ttl_schema.validate_data_matches_field_data_types()

--- a/tests/test_entries_resource.py
+++ b/tests/test_entries_resource.py
@@ -13,9 +13,13 @@ class TestEntriesResourceJson(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries.json'))
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'application/json'
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_response_contents(self, response, entries_schema):
         validate(response.json(), entries_schema)
 
@@ -25,10 +29,12 @@ class TestEntriesResourceYaml(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries.yaml'))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/yaml', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, entries_schema):
         validate(yaml.load(response.text), entries_schema)
 
@@ -38,10 +44,14 @@ class TestEntriesResourceCsv(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries.csv'))
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/csv', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_response_contents(self, response, entry_csv_schema):
         problems = entry_csv_schema.validate(csv.reader(response.text.split('\r\n')))
         assert problems == [], \
@@ -53,10 +63,12 @@ class TestEntriesResourceTsv(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries.tsv'))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/tab-separated-values', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, entry_csv_schema):
         problems = entry_csv_schema.validate(csv.reader(response.text.split('\n'), delimiter='\t'))
         assert problems == [], \
@@ -68,10 +80,12 @@ class TestEntriesResourceTtl(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries.ttl'))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/turtle', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, entry_ttl_schema):
         entry_ttl_schema.add_data(response.text)
         problems = entry_ttl_schema.validate_data_matches_field_data_types()

--- a/tests/test_entry_resource.py
+++ b/tests/test_entry_resource.py
@@ -19,24 +19,26 @@ class TestEntryResourceJson(object):
         assert response.headers['content-type'] == 'application/json'
 
     @pytest.mark.version(1)
+    def test_response_contents(self, response, entry_schema_v1):
+        validate(response.json(), entry_schema_v1)
+
     @pytest.mark.version(2)
-    def test_response_contents(self, response, entry_schema):
-        validate(response.json(), entry_schema)
+    def test_response_contents(self, response, entry_schema_v2):
+        validate(response.json(), entry_schema_v2)
 
 
+@pytest.mark.version(1)
 class TestEntryResourceYaml(object):
     @pytest.fixture
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries/1.yaml'))
 
-    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/yaml', {'charset': 'UTF-8'})
 
-    @pytest.mark.version(1)
-    def test_response_contents(self, response, entry_schema):
-        validate(yaml.load(response.text), entry_schema)
+    def test_response_contents(self, response, entry_schema_v1):
+        validate(yaml.load(response.text), entry_schema_v1)
 
 
 class TestEntryResourceCsv(object):
@@ -51,41 +53,44 @@ class TestEntryResourceCsv(object):
                == ('text/csv', {'charset': 'UTF-8'})
 
     @pytest.mark.version(1)
+    def test_response_contents(self, response, entry_csv_schema_v1):
+        problems = entry_csv_schema_v1.validate(csv.reader(response.text.split('\r\n')))
+        assert problems == [], \
+            'There is a problem with Entry resource csv'
+
     @pytest.mark.version(2)
-    def test_response_contents(self, response, entry_csv_schema):
-        problems = entry_csv_schema.validate(csv.reader(response.text.split('\r\n')))
+    def test_response_contents(self, response, entry_csv_schema_v2):
+        problems = entry_csv_schema_v2.validate(csv.reader(response.text.split('\r\n')))
         assert problems == [], \
             'There is a problem with Entry resource csv'
 
 
+@pytest.mark.version(1)
 class TestEntryResourceTsv(object):
     @pytest.fixture
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries/1.tsv'))
 
-    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/tab-separated-values', {'charset': 'UTF-8'})
 
-    @pytest.mark.version(1)
-    def test_response_contents(self, response, entry_csv_schema):
-        problems = entry_csv_schema.validate(csv.reader(response.text.split('\n'), delimiter='\t'))
+    def test_response_contents(self, response, entry_csv_schema_v1):
+        problems = entry_csv_schema_v1.validate(csv.reader(response.text.split('\n'), delimiter='\t'))
         assert problems == [], \
             'There is a problem with Entry resource tsv'
 
 
+@pytest.mark.version(1)
 class TestEntryResourceTtl(object):
     @pytest.fixture
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entries/1.ttl'))
 
-    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/turtle', {'charset': 'UTF-8'})
 
-    @pytest.mark.version(1)
     def test_response_contents(self, response, entry_ttl_schema):
         entry_ttl_schema.add_data(response.text)
         problems = entry_ttl_schema.validate_data_matches_field_data_types()

--- a/tests/test_entry_resource.py
+++ b/tests/test_entry_resource.py
@@ -13,9 +13,13 @@ class TestEntryResourceJson(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entry/1.json'))
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'application/json'
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_response_contents(self, response, entry_schema):
         validate(response.json(), entry_schema)
 
@@ -25,10 +29,12 @@ class TestEntryResourceYaml(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entry/1.yaml'))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/yaml', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, entry_schema):
         validate(yaml.load(response.text), entry_schema)
 
@@ -38,10 +44,14 @@ class TestEntryResourceCsv(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entry/1.csv'))
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/csv', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_response_contents(self, response, entry_csv_schema):
         problems = entry_csv_schema.validate(csv.reader(response.text.split('\r\n')))
         assert problems == [], \
@@ -53,10 +63,12 @@ class TestEntryResourceTsv(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entry/1.tsv'))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/tab-separated-values', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, entry_csv_schema):
         problems = entry_csv_schema.validate(csv.reader(response.text.split('\n'), delimiter='\t'))
         assert problems == [], \
@@ -68,10 +80,12 @@ class TestEntryResourceTtl(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'entry/1.ttl'))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/turtle', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, entry_ttl_schema):
         entry_ttl_schema.add_data(response.text)
         problems = entry_ttl_schema.validate_data_matches_field_data_types()

--- a/tests/test_entry_resource.py
+++ b/tests/test_entry_resource.py
@@ -11,7 +11,7 @@ from werkzeug.http import parse_options_header
 class TestEntryResourceJson(object):
     @pytest.fixture
     def response(self, endpoint):
-        return requests.get(urljoin(endpoint, 'entry/1.json'))
+        return requests.get(urljoin(endpoint, 'entries/1.json'))
 
     @pytest.mark.version(1)
     @pytest.mark.version(2)
@@ -27,7 +27,7 @@ class TestEntryResourceJson(object):
 class TestEntryResourceYaml(object):
     @pytest.fixture
     def response(self, endpoint):
-        return requests.get(urljoin(endpoint, 'entry/1.yaml'))
+        return requests.get(urljoin(endpoint, 'entries/1.yaml'))
 
     @pytest.mark.version(1)
     def test_content_type(self, response):
@@ -42,7 +42,7 @@ class TestEntryResourceYaml(object):
 class TestEntryResourceCsv(object):
     @pytest.fixture
     def response(self, endpoint):
-        return requests.get(urljoin(endpoint, 'entry/1.csv'))
+        return requests.get(urljoin(endpoint, 'entries/1.csv'))
 
     @pytest.mark.version(1)
     @pytest.mark.version(2)
@@ -61,7 +61,7 @@ class TestEntryResourceCsv(object):
 class TestEntryResourceTsv(object):
     @pytest.fixture
     def response(self, endpoint):
-        return requests.get(urljoin(endpoint, 'entry/1.tsv'))
+        return requests.get(urljoin(endpoint, 'entries/1.tsv'))
 
     @pytest.mark.version(1)
     def test_content_type(self, response):
@@ -78,7 +78,7 @@ class TestEntryResourceTsv(object):
 class TestEntryResourceTtl(object):
     @pytest.fixture
     def response(self, endpoint):
-        return requests.get(urljoin(endpoint, 'entry/1.ttl'))
+        return requests.get(urljoin(endpoint, 'entries/1.ttl'))
 
     @pytest.mark.version(1)
     def test_content_type(self, response):

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -2,7 +2,8 @@ import pytest
 
 from urllib.parse import urlparse
 
-
+@pytest.mark.v1
+@pytest.mark.v2
 @pytest.mark.https
 def test_endpoint_is_https_url(endpoint):
     o = urlparse(endpoint)

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -30,6 +30,8 @@ class ResourceTestBase(object):
 class TestItemResourceJson(ResourceTestBase):
     resource_type = 'json'
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_response_contents(self, response, endpoint):
         register_data = requests.get(urljoin(endpoint, '/register.json'))
         register_fields = register_data.json()['register-record']['fields']
@@ -37,6 +39,8 @@ class TestItemResourceJson(ResourceTestBase):
         assert set(response.json().keys()).issubset(register_fields), \
             'Item json does not match fields specified in register register'
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'application/json'
 
@@ -44,6 +48,7 @@ class TestItemResourceJson(ResourceTestBase):
 class TestItemResourceYaml(ResourceTestBase):
     resource_type = 'yaml'
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, endpoint):
         register_data = requests.get(urljoin(endpoint, '/register.json'))
         register_fields = register_data.json()['register-record']['fields']
@@ -51,6 +56,7 @@ class TestItemResourceYaml(ResourceTestBase):
         assert set(yaml.load(response.text).keys()).issubset(register_fields), \
             'Item json does not match fields specified in register register'
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/yaml', {'charset': 'UTF-8'})
@@ -59,6 +65,8 @@ class TestItemResourceYaml(ResourceTestBase):
 class TestItemResourceCsv(ResourceTestBase):
     resource_type = 'csv'
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_response_contents(self, response, endpoint):
         csv_schema = self.get_schema(endpoint)
         problems = csv_schema.validate(csv.reader(response.text.split('\r\n')))
@@ -66,6 +74,8 @@ class TestItemResourceCsv(ResourceTestBase):
         assert problems == [], \
             'There is a problem with Item resource csv'
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/csv', {'charset': 'UTF-8'})
@@ -74,6 +84,7 @@ class TestItemResourceCsv(ResourceTestBase):
 class TestItemResourceTsv(ResourceTestBase):
     resource_type = 'tsv'
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, endpoint):
         tsv_schema = self.get_schema(endpoint)
         problems = tsv_schema.validate(csv.reader(response.text.split('\n'), delimiter='\t'))
@@ -81,6 +92,7 @@ class TestItemResourceTsv(ResourceTestBase):
         assert problems == [], \
             'There is a problem with Item resource tsv'
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/tab-separated-values', {'charset': 'UTF-8'})
@@ -89,6 +101,7 @@ class TestItemResourceTsv(ResourceTestBase):
 class TestItemResourceTtl(ResourceTestBase):
     resource_type = 'ttl'
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, endpoint, entry_ttl_schema, register_domain):
         register_data = requests.get(urljoin(endpoint, '/register.json'))
         register_fields = register_data.json()['register-record']['fields']
@@ -104,6 +117,7 @@ class TestItemResourceTtl(ResourceTestBase):
         assert problems == [], \
             'There is a problem with Item resource ttl'
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/turtle', {'charset': 'UTF-8'})

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -8,15 +8,15 @@ from urllib.parse import urljoin
 from werkzeug.http import parse_options_header
 
 
-class ResourceTestBase(object):
+class ResourceTestBase:
     resource_type = ''
 
     @pytest.fixture(autouse=True)
     def response(self, endpoint):
-        entry = requests.get(urljoin(endpoint, 'entry/1.json'))
+        entry = requests.get(urljoin(endpoint, 'entries/1.json'))
         item_hash = entry.json()[0]['item-hash'][0]
 
-        return requests.get(urljoin(endpoint, 'item/%s.%s' % (item_hash, self.resource_type)))
+        return requests.get(urljoin(endpoint, 'items/%s.%s' % (item_hash, self.resource_type)))
 
     def get_schema(self, endpoint):
         register_data = requests.get(urljoin(endpoint, '/register.json'))

--- a/tests/test_item_resource.py
+++ b/tests/test_item_resource.py
@@ -11,12 +11,23 @@ from werkzeug.http import parse_options_header
 class ResourceTestBase:
     resource_type = ''
 
-    @pytest.fixture(autouse=True)
-    def response(self, endpoint):
+    @pytest.fixture
+    def item_hash(self, endpoint):
         entry = requests.get(urljoin(endpoint, 'entries/1.json'))
-        item_hash = entry.json()[0]['item-hash'][0]
+        return entry.json()[0]['item-hash'][0]
 
+    @pytest.fixture
+    def blob_hash(self, endpoint):
+        entry = requests.get(urljoin(endpoint, 'entries/1.json'))
+        return entry.json()[0]['blob-hash'][0]
+
+    @pytest.fixture
+    def item_response(self, endpoint, item_hash):
         return requests.get(urljoin(endpoint, 'items/%s.%s' % (item_hash, self.resource_type)))
+
+    @pytest.fixture
+    def blob_response(self, endpoint, blob_hash):
+        return requests.get(urljoin(endpoint, 'blobs/%s.%s' % (blob_hash, self.resource_type)))
 
     def get_schema(self, endpoint):
         register_data = requests.get(urljoin(endpoint, '/register.json'))
@@ -27,87 +38,110 @@ class ResourceTestBase:
         return validator
 
 
-class TestItemResourceJson(ResourceTestBase):
+@pytest.mark.version(1)
+class TestItemResourceJsonV1(ResourceTestBase):
     resource_type = 'json'
 
-    @pytest.mark.version(1)
-    @pytest.mark.version(2)
-    def test_response_contents(self, response, endpoint):
+    def test_response_contents(self, item_response, endpoint):
         register_data = requests.get(urljoin(endpoint, '/register.json'))
         register_fields = register_data.json()['register-record']['fields']
 
-        assert set(response.json().keys()).issubset(register_fields), \
+        assert set(item_response.json().keys()).issubset(register_fields), \
             'Item json does not match fields specified in register register'
 
-    @pytest.mark.version(1)
-    @pytest.mark.version(2)
-    def test_content_type(self, response):
-        assert response.headers['content-type'] == 'application/json'
+    def test_content_type(self, item_response):
+        assert item_response.headers['content-type'] == 'application/json'
 
 
+@pytest.mark.version(2)
+class TestItemResourceJsonV2(ResourceTestBase):
+    resource_type = 'json'
+
+    def test_response_contents(self, blob_response, endpoint):
+        register_data = requests.get(urljoin(endpoint, '/register.json'))
+        register_fields = register_data.json()['register-record']['fields']
+
+        assert set(blob_response.json().keys()).issubset(register_fields), \
+            'Item json does not match fields specified in register register'
+
+    def test_content_type(self, blob_response):
+        assert blob_response.headers['content-type'] == 'application/json'
+
+
+@pytest.mark.version(1)
 class TestItemResourceYaml(ResourceTestBase):
     resource_type = 'yaml'
 
-    @pytest.mark.version(1)
-    def test_response_contents(self, response, endpoint):
+    def test_response_contents(self, item_response, endpoint):
         register_data = requests.get(urljoin(endpoint, '/register.json'))
         register_fields = register_data.json()['register-record']['fields']
 
-        assert set(yaml.load(response.text).keys()).issubset(register_fields), \
+        assert set(yaml.load(item_response.text).keys()).issubset(register_fields), \
             'Item json does not match fields specified in register register'
 
-    @pytest.mark.version(1)
-    def test_content_type(self, response):
-        assert parse_options_header(response.headers['content-type']) \
+    def test_content_type(self, item_response):
+        assert parse_options_header(item_response.headers['content-type']) \
                == ('text/yaml', {'charset': 'UTF-8'})
 
 
+@pytest.mark.version(1)
 class TestItemResourceCsv(ResourceTestBase):
     resource_type = 'csv'
 
-    @pytest.mark.version(1)
-    @pytest.mark.version(2)
-    def test_response_contents(self, response, endpoint):
+    def test_response_contents(self, item_response, endpoint):
         csv_schema = self.get_schema(endpoint)
-        problems = csv_schema.validate(csv.reader(response.text.split('\r\n')))
+        problems = csv_schema.validate(csv.reader(item_response.text.split('\r\n')))
 
         assert problems == [], \
             'There is a problem with Item resource csv'
 
-    @pytest.mark.version(1)
-    @pytest.mark.version(2)
-    def test_content_type(self, response):
-        assert parse_options_header(response.headers['content-type']) \
+    def test_content_type(self, item_response):
+        assert parse_options_header(item_response.headers['content-type']) \
                == ('text/csv', {'charset': 'UTF-8'})
 
 
+@pytest.mark.version(2)
+class TestItemResourceCsv(ResourceTestBase):
+    resource_type = 'csv'
+
+    def test_response_contents(self, blob_response, endpoint):
+        csv_schema = self.get_schema(endpoint)
+        problems = csv_schema.validate(csv.reader(blob_response.text.split('\r\n')))
+
+        assert problems == [], \
+            'There is a problem with Item resource csv'
+
+    def test_content_type(self, blob_response):
+        assert parse_options_header(blob_response.headers['content-type']) \
+               == ('text/csv', {'charset': 'UTF-8'})
+
+
+@pytest.mark.version(1)
 class TestItemResourceTsv(ResourceTestBase):
     resource_type = 'tsv'
 
-    @pytest.mark.version(1)
-    def test_response_contents(self, response, endpoint):
+    def test_response_contents(self, item_response, endpoint):
         tsv_schema = self.get_schema(endpoint)
-        problems = tsv_schema.validate(csv.reader(response.text.split('\n'), delimiter='\t'))
+        problems = tsv_schema.validate(csv.reader(item_response.text.split('\n'), delimiter='\t'))
 
         assert problems == [], \
             'There is a problem with Item resource tsv'
 
-    @pytest.mark.version(1)
-    def test_content_type(self, response):
-        assert parse_options_header(response.headers['content-type']) \
+    def test_content_type(self, item_response):
+        assert parse_options_header(item_response.headers['content-type']) \
                == ('text/tab-separated-values', {'charset': 'UTF-8'})
 
 
+@pytest.mark.version(1)
 class TestItemResourceTtl(ResourceTestBase):
     resource_type = 'ttl'
 
-    @pytest.mark.version(1)
-    def test_response_contents(self, response, endpoint, entry_ttl_schema, register_domain):
+    def test_response_contents(self, item_response, endpoint, entry_ttl_schema, register_domain):
         register_data = requests.get(urljoin(endpoint, '/register.json'))
         register_fields = register_data.json()['register-record']['fields']
         namespace = 'http://field.%s/records/' % register_domain
 
-        entry_ttl_schema.add_data(response.text)
+        entry_ttl_schema.add_data(item_response.text)
         entry_ttl_schema.add_fields(namespace, register_fields)
         entry_ttl_schema.add_entry_fields_to_validation()
 
@@ -117,7 +151,6 @@ class TestItemResourceTtl(ResourceTestBase):
         assert problems == [], \
             'There is a problem with Item resource ttl'
 
-    @pytest.mark.version(1)
-    def test_content_type(self, response):
-        assert parse_options_header(response.headers['content-type']) \
+    def test_content_type(self, item_response):
+        assert parse_options_header(item_response.headers['content-type']) \
                == ('text/turtle', {'charset': 'UTF-8'})

--- a/tests/test_record_entries_resource.py
+++ b/tests/test_record_entries_resource.py
@@ -12,8 +12,9 @@ class TestRecordEntriesResourceJson(object):
     @pytest.fixture
     def response(self, endpoint, register):
         register_name = register
-        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()[0]
-        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'][0])).json()
+        entry_json = requests.get(urljoin(endpoint, 'entries/1.json')).json()[0]
+        item_json = requests.get(urljoin(endpoint, 'items/%s.json' % entry_json['item-hash'][0])).json()
+
 
         return requests.get(urljoin(endpoint, '/records/%s/entries.json' % item_json[register_name]))
 

--- a/tests/test_record_entries_resource.py
+++ b/tests/test_record_entries_resource.py
@@ -88,13 +88,12 @@ class TestRecordEntriesResourceCsvV2(object):
         entry_json = requests.get(urljoin(endpoint, 'entries/1.json')).json()[0]
         blob_json = requests.get(urljoin(endpoint, 'blobs/%s.json' % entry_json['blob-hash'][0])).json()
 
-        return requests.get(urljoin(endpoint, '/records/%s/entries.csv' % blob_json[register_name]))
+        return requests.get(urljoin(endpoint, 'records/%s/entries.csv' % blob_json[register_name]))
 
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/csv', {'charset': 'UTF-8'})
 
-    @pytest.mark.xfail(reason='Currently broken: Fix it!')
     def test_response_contents(self, response, entry_csv_schema_v2):
         problems = entry_csv_schema_v2.validate(csv.reader(response.text.split('\r\n')))
         assert problems == [], \
@@ -109,7 +108,7 @@ class TestRecordEntriesResourceTsv(object):
         entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()[0]
         item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'][0])).json()
 
-        return requests.get(urljoin(endpoint, '/records/%s/entries.tsv' % item_json[register_name]))
+        return requests.get(urljoin(endpoint, 'records/%s/entries.tsv' % item_json[register_name]))
 
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \

--- a/tests/test_record_entries_resource.py
+++ b/tests/test_record_entries_resource.py
@@ -17,9 +17,13 @@ class TestRecordEntriesResourceJson(object):
 
         return requests.get(urljoin(endpoint, '/records/%s/entries.json' % item_json[register_name]))
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'application/json'
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_response_contents(self, response, entries_schema):
         validate(response.json(), entries_schema)
 
@@ -33,10 +37,12 @@ class TestRecordEntriesResourceYaml(object):
 
         return requests.get(urljoin(endpoint, '/records/%s/entries.yaml' % item_json[register_name]))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/yaml', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, entries_schema):
         validate(yaml.load(response.text), entries_schema)
 
@@ -50,10 +56,14 @@ class TestRecordEntriesResourceCsv(object):
 
         return requests.get(urljoin(endpoint, '/records/%s/entries.csv' % item_json[register_name]))
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/csv', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_response_contents(self, response, entry_csv_schema):
         problems = entry_csv_schema.validate(csv.reader(response.text.split('\r\n')))
         assert problems == [], \
@@ -69,10 +79,12 @@ class TestRecordEntriesResourceTsv(object):
 
         return requests.get(urljoin(endpoint, '/records/%s/entries.tsv' % item_json[register_name]))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/tab-separated-values', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, entry_csv_schema):
         problems = entry_csv_schema.validate(csv.reader(response.text.split('\n'), delimiter='\t'))
         assert problems == [], \
@@ -88,10 +100,12 @@ class TestRecordEntriesResourceTtl(object):
 
         return requests.get(urljoin(endpoint, '/records/%s/entries.ttl' % item_json[register_name]))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/turtle', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, entry_ttl_schema):
         entry_ttl_schema.add_data(response.text)
         problems = entry_ttl_schema.validate_data_matches_field_data_types()

--- a/tests/test_record_resource.py
+++ b/tests/test_record_resource.py
@@ -14,8 +14,8 @@ class TestRecordResourceJson(object):
     @pytest.fixture
     def response(self, endpoint, register):
         register_name = register
-        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()[0]
-        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'][0])).json()
+        entry_json = requests.get(urljoin(endpoint, 'entries/1.json')).json()[0]
+        item_json = requests.get(urljoin(endpoint, 'items/%s.json' % entry_json['item-hash'][0])).json()
 
         return item_json[register_name], requests.get(urljoin(endpoint, '/records/%s.json' % item_json[register_name]))
 
@@ -44,8 +44,8 @@ class TestRecordResourceYaml(object):
     @pytest.fixture
     def response(self, endpoint, register):
         register_name = register
-        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()[0]
-        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'][0])).json()
+        entry_json = requests.get(urljoin(endpoint, 'entries/1.json')).json()[0]
+        item_json = requests.get(urljoin(endpoint, 'items/%s.json' % entry_json['item-hash'][0])).json()
 
         return item_json[register_name], requests.get(urljoin(endpoint, '/records/%s.yaml' % item_json[register_name]))
 
@@ -77,8 +77,8 @@ class TestRecordResourceCsv(object):
     @pytest.fixture
     def response(self, endpoint, register):
         register_name = register
-        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()[0]
-        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'][0])).json()
+        entry_json = requests.get(urljoin(endpoint, 'entries/1.json')).json()[0]
+        item_json = requests.get(urljoin(endpoint, 'items/%s.json' % entry_json['item-hash'][0])).json()
 
         return requests.get(urljoin(endpoint, '/records/%s.csv' % item_json[register_name]))
 
@@ -102,8 +102,8 @@ class TestRecordResourceTsv(object):
     @pytest.fixture
     def response(self, endpoint, register):
         register_name = register
-        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()[0]
-        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'][0])).json()
+        entry_json = requests.get(urljoin(endpoint, 'entries/1.json')).json()[0]
+        item_json = requests.get(urljoin(endpoint, 'items/%s.json' % entry_json['item-hash'][0])).json()
 
         return requests.get(urljoin(endpoint, '/records/%s.tsv' % item_json[register_name]))
 
@@ -125,8 +125,8 @@ class TestRecordResourceTtl(object):
     @pytest.fixture
     def response(self, endpoint, register):
         register_name = register
-        entry_json = requests.get(urljoin(endpoint, 'entry/1.json')).json()[0]
-        item_json = requests.get(urljoin(endpoint, 'item/%s.json' % entry_json['item-hash'][0])).json()
+        entry_json = requests.get(urljoin(endpoint, 'entries/1.json')).json()[0]
+        item_json = requests.get(urljoin(endpoint, 'items/%s.json' % entry_json['item-hash'][0])).json()
 
         return requests.get(urljoin(endpoint, '/records/%s.ttl' % item_json[register_name]))
 

--- a/tests/test_record_resource.py
+++ b/tests/test_record_resource.py
@@ -19,10 +19,14 @@ class TestRecordResourceJson(object):
 
         return item_json[register_name], requests.get(urljoin(endpoint, '/records/%s.json' % item_json[register_name]))
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_content_type(self, response):
         key, record_response = response
         assert record_response.headers['content-type'] == 'application/json'
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_response_contents(self, response, endpoint, record_schema):
         key, record_response = response
 
@@ -45,11 +49,13 @@ class TestRecordResourceYaml(object):
 
         return item_json[register_name], requests.get(urljoin(endpoint, '/records/%s.yaml' % item_json[register_name]))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         key, record_response = response
         assert parse_options_header(record_response.headers['content-type']) \
                == ('text/yaml', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     @pytest.mark.xfail(reason="""yaml.load decodes some register keys as integers because we do not wrap our codes in apostrophes.
         This will fail for some registers and not others and might be a problem with our YAML representation.""")
     def test_response_contents(self, response, endpoint, record_schema):
@@ -76,10 +82,14 @@ class TestRecordResourceCsv(object):
 
         return requests.get(urljoin(endpoint, '/records/%s.csv' % item_json[register_name]))
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/csv', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
+    @pytest.mark.version(2)
     def test_response_contents(self, response, endpoint):
         csv_schema = get_schema(endpoint)
         problems = csv_schema.validate(csv.reader(response.text.split('\r\n')))
@@ -97,10 +107,12 @@ class TestRecordResourceTsv(object):
 
         return requests.get(urljoin(endpoint, '/records/%s.tsv' % item_json[register_name]))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/tab-separated-values', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, endpoint):
         tsv_schema = get_schema(endpoint)
         problems = tsv_schema.validate(csv.reader(response.text.split('\n'), delimiter='\t'))
@@ -118,10 +130,12 @@ class TestRecordResourceTtl(object):
 
         return requests.get(urljoin(endpoint, '/records/%s.ttl' % item_json[register_name]))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert parse_options_header(response.headers['content-type']) \
                == ('text/turtle', {'charset': 'UTF-8'})
 
+    @pytest.mark.version(1)
     def test_response_contents(self, response, endpoint, record_ttl_schema, register_domain):
         field_namespace = 'http://field.%s/records/' % register_domain
         register_data = requests.get(urljoin(endpoint, '/register.json'))

--- a/tests/test_register_resource.py
+++ b/tests/test_register_resource.py
@@ -49,31 +49,29 @@ REGISTER_RESOURCE_SCHEMA = {
 }
 
 
+@pytest.mark.version(1)
 class TestRegisterResourceJson(object):
     @pytest.fixture
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'register.json'))
 
-    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'application/json'
 
     @pytest.mark.xfail(reason='Missing total-items')
-    @pytest.mark.version(1)
     def test_response_contents(self, response):
         validate(response.json(), REGISTER_RESOURCE_SCHEMA)
 
 
+@pytest.mark.version(1)
 class TestRegisterResourceYaml(object):
     @pytest.fixture
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'register.yaml'))
 
-    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'text/yaml;charset=UTF-8'
 
     @pytest.mark.xfail(reason='missing total-items')
-    @pytest.mark.version(1)
     def test_response_contents(self, response):
         validate(yaml.load(response.text), REGISTER_RESOURCE_SCHEMA)

--- a/tests/test_register_resource.py
+++ b/tests/test_register_resource.py
@@ -54,10 +54,12 @@ class TestRegisterResourceJson(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'register.json'))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'application/json'
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason='Missing total-items')
+    @pytest.mark.version(1)
     def test_response_contents(self, response):
         validate(response.json(), REGISTER_RESOURCE_SCHEMA)
 
@@ -67,9 +69,11 @@ class TestRegisterResourceYaml(object):
     def response(self, endpoint):
         return requests.get(urljoin(endpoint, 'register.yaml'))
 
+    @pytest.mark.version(1)
     def test_content_type(self, response):
         assert response.headers['content-type'] == 'text/yaml;charset=UTF-8'
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason='missing total-items')
+    @pytest.mark.version(1)
     def test_response_contents(self, response):
         validate(yaml.load(response.text), REGISTER_RESOURCE_SCHEMA)


### PR DESCRIPTION
https://github.com/openregister/openregister-java/pull/518 is the first PR that adds "version 2" functionality.

We will at some point soon start tagging the specification with versions, but for the time being
- V1 is defined by https://openregister.github.io/specification/
- V2 is effectively whatever we decide to ship by the end of the year. It is V1 plus breaking changes coming out of [accepted RFCs](https://github.com/openregister/registers-rfcs)

This PR adds a way to run the conformance tests against either version.

- [x] Tests pass against V1
- [x] Tests pass against V2 (for https://github.com/openregister/openregister-java/pull/518)
- [x] Updated README

All tests now need to be marked with the version of the specification they are testing, e.g. `@pytest.mark.version(1)`.  I'm using [custom markers](https://docs.pytest.org/en/latest/example/markers.html#custom-marker-and-command-line-option-to-control-test-runs) in the `conftest.py` rather than the simple kind of markers, because we already use markers to mark HTTPS tests, and the `-m` flag is not expressive enough to let you combine the two kinds of filtering.

The V2 tests are not complete at the moment, but I will add them as I do further work on the reference implementation.