### PR TITLE
Change the structure of the /blobs endpoint in v2

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,49 @@ def records_schema_v2():
 
 
 @pytest.fixture(scope='session')
+def blobs_schema():
+    return {
+        'type': 'array',
+        'items': {
+                'type': 'object',
+                "propertyNames" : {
+                    "pattern": types.NAME_PATTERN
+                },
+                'properties': {
+                    **types.BLOB_ID,
+                },
+                'required': ['_id'],
+                'additionalProperties':  {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "array", 'items': {'type': 'string'}}
+                    ]
+                }
+            }
+        }
+
+
+@pytest.fixture(scope='session')
+def blob_schema():
+    return {
+        'type': 'object',
+        "propertyNames" : {
+            "pattern": types.NAME_PATTERN
+        },
+        'properties': {
+            **types.BLOB_ID,
+        },
+        'required': ['_id'],
+        'additionalProperties':  {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "array", 'items': {'type': 'string'}}
+            ]
+        }
+    }
+
+
+@pytest.fixture(scope='session')
 def entry_csv_schema_v1():
     validator = CSVValidator(('index-entry-number', 'entry-number', 'entry-timestamp', 'key', 'item-hash'))
     validator.add_header_check()

--- a/tests/data_types.py
+++ b/tests/data_types.py
@@ -49,6 +49,13 @@ BLOB_HASH = {
     }
 }
 
+BLOB_ID = {
+    '_id': {
+        'type': 'string',
+        'pattern': HASH_PATTERN
+    }
+}
+
 ITEM = {
     'item': {
         'type': 'array',

--- a/tests/test_blobs_resource.py
+++ b/tests/test_blobs_resource.py
@@ -1,0 +1,56 @@
+import csv
+import pytest
+import requests
+import warnings
+
+from csvvalidator import CSVValidator
+from urllib.parse import urljoin
+from jsonschema import validate
+
+@pytest.fixture
+def register_fields(endpoint):
+    '''
+    Ask the register for its fields
+    TODO: this will be superseded by the context endpoint in V2
+    '''
+    register_data = requests.get(urljoin(endpoint, 'register.json'))
+    return register_data.json()['register-record']['fields']
+
+
+@pytest.mark.version(2)
+class TestBlobsResourceJSON:
+    def test_response_contents(self, register_fields, blobs_schema, endpoint):
+        response = requests.get(urljoin(endpoint, 'blobs'))
+        parsed_response = response.json()
+
+        validate(parsed_response, blobs_schema)
+
+        if not parsed_response:
+            warnings.warn('Some checks were skipped because the register contains no blobs.', warnings.RuntimeWarning)
+
+        for blob in parsed_response:
+            blob_keys = set(blob.keys() - ['_id'])
+            assert blob_keys.issubset(register_fields), 'Blob json does not match fields specified in the register definition'
+
+    def test_content_type(self, endpoint):
+        response = requests.get(urljoin(endpoint, 'blobs'))
+
+        assert response.headers['content-type'] == 'application/json'
+
+
+@pytest.mark.version(2)
+class TestBlobsResourceCSV:
+    def test_response_contents(self, register_fields, endpoint):
+        response = requests.get(urljoin(endpoint, 'blobs.csv'))
+
+        validator = CSVValidator(['_id'] + register_fields)
+        validator.add_header_check()
+
+        problems = validator.validate(csv.reader(response.text.split('\r\n')))
+
+        assert problems == [], '/blobs CSV fields do not match the register definition'
+
+    def test_content_type(self, endpoint):
+        response = requests.get(urljoin(endpoint, 'blobs.csv'))
+
+        assert response.headers['content-type'] == 'text/csv;charset=UTF-8'


### PR DESCRIPTION
We are planning on changing this to an array for consistency with the other collection endpoints. This is not reflected in the spec yet but will be.

`_id` for a blob refers to the blob hash.