### PR TITLE
Add context endpoint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+import requests
+from urllib.parse import urljoin
 
 import tests.data_types as types
 from csvvalidator import *
@@ -212,6 +214,36 @@ def blob_schema():
 
 
 @pytest.fixture(scope='session')
+def context_schema():
+    return {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "pattern": types.NAME_PATTERN
+            },
+            "title": {"type": "string"},
+            "copyright": {"type": "string"},
+            "custodian": {"type": "string"},
+            "description": {"type": "string"},
+            "hashing_algorithm": types.HASHING_ALGORITHM,
+            "licence": {"type": "string"},
+            "root-hash": {
+                "type": "string",
+                "pattern": "^[a-f0-9]+$"
+            },
+            "schema": types.SCHEMA,
+            "statistics": types.STATISTICS,
+            "status": types.STATUS,
+            "title": {
+            "type": "string"
+            }
+        },
+        "required": ["id", "hashing-algorithm", "root-hash", "schema", "statistics", "status"]
+    }
+
+
+@pytest.fixture(scope='session')
 def entry_csv_schema_v1():
     validator = CSVValidator(('index-entry-number', 'entry-number', 'entry-timestamp', 'key', 'item-hash'))
     validator.add_header_check()
@@ -232,3 +264,8 @@ def entry_csv_schema_v2():
     validator.add_value_check('entry-timestamp', str, match_pattern(types.TIMESTAMP_PATTERN))
     validator.add_value_check('key', str, match_pattern(types.KEY_PATTERN))
     return validator
+
+
+def get_register_fields(endpoint):
+    register_data = requests.get(urljoin(endpoint, 'context.json'))
+    return [field['id'] for field in register_data.json()['schema']]

--- a/tests/data_types.py
+++ b/tests/data_types.py
@@ -92,3 +92,75 @@ RECORD_ID = {
         'pattern': KEY_PATTERN
     }
 }
+
+HASHING_ALGORITHM = {
+    'type': 'object',
+    'properties': {
+        'digest-length': {'type': 'integer'},
+        'function-type': {'type': 'integer'},
+        'codec': {'type': 'string'}
+    },
+    'required': ['digest-length', 'function-type', 'codec']
+}
+
+STATISTICS = {
+    'type': 'object',
+    'properties': {
+        'total-records': {'type': 'integer'},
+        'total-entries': {'type': 'integer'},
+        'total-items': {'type': 'integer'}
+    },
+    'required': ['total-records', 'total-entries', 'total-items']
+}
+
+STATUS = {
+    'type': 'object',
+    'properties': {
+        'start-date': {'type': 'string', 'format': 'date-time'},
+        'end-date': {'type': 'string', 'format': 'date-time'},
+        'replacement': {'type': 'string', 'format': 'uri'},
+        'reason': {'type': 'string'}
+    },
+    'required': ['start-date']
+}
+
+SCHEMA = {
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "pattern": KEY_PATTERN,
+      },
+      "datatype": {
+        "type": "string",
+        "enum": [
+          "curie",
+          "datetime",
+          "name",
+          "hash",
+          "integer",
+          "period",
+          "string",
+          "text",
+          "url"
+        ]
+      },
+      "cardinality": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "id",
+      "datatype",
+      "cardinality"
+    ]
+  }
+}

--- a/tests/test_blobs_resource.py
+++ b/tests/test_blobs_resource.py
@@ -7,15 +7,15 @@ from csvvalidator import CSVValidator
 from urllib.parse import urljoin
 from jsonschema import validate
 from multihash import multihash
+from .conftest import get_register_fields
+
 
 @pytest.fixture
 def register_fields(endpoint):
     '''
     Ask the register for its fields
-    TODO: this will be superseded by the context endpoint in V2
     '''
-    register_data = requests.get(urljoin(endpoint, 'register.json'))
-    return register_data.json()['register-record']['fields']
+    return get_register_fields(endpoint)
 
 
 @pytest.mark.version(2)

--- a/tests/test_context_resource.py
+++ b/tests/test_context_resource.py
@@ -1,0 +1,21 @@
+import csv
+import pytest
+import requests
+import warnings
+
+from csvvalidator import CSVValidator
+from urllib.parse import urljoin
+from jsonschema import validate
+from multihash import multihash
+
+
+@pytest.mark.version(2)
+class TestContextResourceJSON:
+    def test_response_contents(self, context_schema, endpoint):
+        response = requests.get(urljoin(endpoint, 'context'))
+        parsed_response = response.json()
+        validate(parsed_response, context_schema)
+
+    def test_content_type(self, endpoint):
+        response = requests.get(urljoin(endpoint, 'context'))
+        assert response.headers['content-type'] == 'application/json'


### PR DESCRIPTION
This adds a couple of tests for the /context endpoint, and changes all V2 requests to use /context for fixtures (instead of /register, which doesn't exist for V2).

This should match the description in https://github.com/openregister/registers-rfcs/blob/master/content/context-resource/index.md