### PR TITLE
total-items attribute should be total-blobs

### DIFF
--- a/tests/data_types.py
+++ b/tests/data_types.py
@@ -108,9 +108,9 @@ STATISTICS = {
     'properties': {
         'total-records': {'type': 'integer'},
         'total-entries': {'type': 'integer'},
-        'total-items': {'type': 'integer'}
+        'total-blobs': {'type': 'integer'}
     },
-    'required': ['total-records', 'total-entries', 'total-items']
+    'required': ['total-records', 'total-entries', 'total-blobs']
 }
 
 STATUS = {


### PR DESCRIPTION
This fixes a mistake in the `/context` endpoint.