### PR TITLE
fix: bump urllib3 version to address CVE-2019-11324

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ pytest==3.10.0
 rdflib==4.2.1
 requests==2.20.0
 six==1.11.0
-urllib3==1.24.1
+urllib3==1.24.2
 Werkzeug==0.11.5
 py-multihash==0.2.3


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2019-11324